### PR TITLE
Rouding bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -36,9 +36,7 @@ function dispHeader() {
         var temp = "" + ((hour > 12) ? hour - 12 : hour);
 
         if (hour == 0) { temp = "12"; }
-        if (second > 30) { minute += 1; }
         temp += ((minute < 10) ? ":0" : ":") + minute;
-        // temp += ((hour >= 12) ? " pm" : " am");
         return temp;
     }
     function defMoment(date) {


### PR DESCRIPTION
previous : rounding minute to (minute + 1) could result in 11:60  for example.
Taken out simply, with consequence that the minutes displayed could be up to 59 sec late. 